### PR TITLE
FROMからHEADの間に追加したファイルがZIPに含まれていない

### DIFF
--- a/diffgen.sh
+++ b/diffgen.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -u
 
 read -p "FROM: " FROM
-git archive --format=zip $FROM `git diff --name-only --diff-filter=AMCR HEAD $FROM` -o diff_archive.zip
+git archive --format=zip --prefix=diff_archive/ HEAD `git diff --name-only HEAD $FROM` -o diff_archive.zip
 
 # See
 # http://qiita.com/hironaito/items/9b5135698ea1a497a3c0


### PR DESCRIPTION
例）`diffgen af8cc80` : README.mdが含まれていない。

**解凍時に同じフォルダ名が出てきてわかりづらい**
